### PR TITLE
Fixed the rendering when there are groups and a layer is added

### DIFF
--- a/src/leaflet-panel-layers.js
+++ b/src/leaflet-panel-layers.js
@@ -50,15 +50,20 @@ L.Control.PanelLayers = L.Control.Layers.extend({
 	addBaseLayer: function (layer, name, group) {
 		layer.name = name || layer.name || '';
 		this._addLayer(layer, false, group);
-		this._update();
+		this._updateLayers();
 		return this;
 	},
 
 	addOverlay: function (layer, name, group) {
 		layer.name = name || layer.name || '';
 		this._addLayer(layer, true, group);
-		this._update();
+		this._updateLayers();
 		return this;
+	},
+	
+	_updateLayers: function () {
+		this._groups = {};
+		this._update();
 	},
 
 	_instanceLayer: function(layerDef) {


### PR DESCRIPTION
When a layer is added after the initial creation, any groups vanish. The `_update()` function clears out the html of the base and overlay divs, and then recreates all the items using `_addItem`. However the `_groups` hash still contains the previous html element, so new groups do not get created. This change clears out the `_groups` hash before calling `_update`.