### PR TITLE
Stop scroll/click propagation regardless of Browser.touch

### DIFF
--- a/src/leaflet-panel-layers.js
+++ b/src/leaflet-panel-layers.js
@@ -353,15 +353,9 @@ L.Control.PanelLayers = L.Control.Layers.extend({
 		//Makes this work on IE10 Touch devices by stopping it from firing a mouseout event when the touch is released
 		container.setAttribute('aria-haspopup', true);
 
-		if (!L.Browser.touch) {
-			L.DomEvent
-				.disableClickPropagation(container)
-				.disableScrollPropagation(container);
-		} else
-			L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
-
-		//FIX IE 11 drag problem
-		L.DomEvent.disableClickPropagation(container);
+		L.DomEvent
+			.disableClickPropagation(container)
+			.disableScrollPropagation(container);
 
 		if (this.options.className)
 			L.DomUtil.addClass(container, this.options.className);


### PR DESCRIPTION
Fixes #38 
The same way as in [Leaflet 1.1.0+](https://github.com/Leaflet/Leaflet/blob/fc043f01f46088306c7ab548f4fef41431dadba8/src/control/Control.Layers.js#L182-L183)
```
DomEvent.disableClickPropagation(container);
DomEvent.disableScrollPropagation(container);
```
