### PR TITLE
Leaflet 1.4 missing this._section exception fix.

### DIFF
--- a/src/leaflet-panel-layers.js
+++ b/src/leaflet-panel-layers.js
@@ -361,7 +361,7 @@ L.Control.PanelLayers = L.Control.Layers.extend({
 		if (this.options.className)
 			L.DomUtil.addClass(container, this.options.className);
 
-		this._form = L.DomUtil.create('form', this.className + '-list');
+		this._section = this._form = L.DomUtil.create('form', this.className + '-list');
 
 		this._updateHeight();
 


### PR DESCRIPTION
Quick patch. In _initLayout I've added this._section used in Leaflet 1.4, and I've left this._form used in the plugin.

It closes #46 and #45.